### PR TITLE
[TCHL-6] Correzione link del verbale esterno

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ La repository e' strutturata nella seguente maniera:
       - [Verable del 20 Ottobre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/1%20-%20Candidatura/Verbali/Verbali%20interni/verbale_20_10_2023.pdf)
       - [Verable del 21 Ottobre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/1%20-%20Candidatura/Verbali/Verbali%20interni/verbale_21_10_2023.pdf)
     - Esterni
-      - [Verable esterno del 21 Ottobre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/readme-update/1%20-%20Candidatura/Verbali/Verbali%20esterni/verbale_esterno_23_10_2023.pdf)
+      - [Verable esterno del 21 Ottobre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/1%20-%20Candidatura/Verbali/Verbali%20esterni/verbale_esterno_23_10_2023.pdf)


### PR DESCRIPTION
Corretto il link del verbale esterno, che rimandava al file di un branch non più disponibile, tornando un errore 404.