### PR TITLE
[TCHL-14] Aggiunto il link all verbale interno

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ La repository e' strutturata nella seguente maniera:
   
   - Verbali
   - Interni
-     - [Verbale dell'11 Novembre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/2%20-%20RTB/Verbali/Verbali%20interni/verbale_2023_11_06.pdf)
+     - [Verbale del 6 Novembre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/2%20-%20RTB/Verbali/Verbali%20interni/verbale_2023_11_06.pdf)
+     - [Verbale dell'11 Novembre 2023](https://github.com/Torchlight-SWE2324/Documentazione/blob/main/2%20-%20RTB/Verbali/Verbali%20interni/verbale_2023_11_11.pdf)


### PR DESCRIPTION
Aggiunto il il link al verbale interno dell'11 novembre.
È stato inoltre corretto un errore di battitura sulla data del precedente verbale.